### PR TITLE
Fix UnicodeDecodeError on Windows by specifying UTF-8 encoding for RE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ class ModelComparison:
 ```bash
 git clone https://github.com/shawnrhoads/pyEM.git
 cd pyEM
-conda create env --file environment.yml
+conda env reate --file environment.yml
 ```
 
 ### Using GitHub

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ class ModelComparison:
 ```bash
 git clone https://github.com/shawnrhoads/pyEM.git
 cd pyEM
-conda env reate --file environment.yml
+conda env create --file environment.yml
 ```
 
 ### Using GitHub

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ github_url = 'https://github.com/shawnrhoads/pyEM'
 authors = ["Shawn A. Rhoads"]
 
 # Get long description
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     __long_description__ = fh.read()
 
 # Get requirements from requirements.txt, ignoring editable/local refs


### PR DESCRIPTION
This PR fixes two installation-breaking issues:
1. Invalid conda command in README
The installation instructions (line 511) use:
`conda create env --file environment.yml`
create and env create are different subcommands — this gets parsed as conda create with env as a positional package name, and no -n/--name given, causing:
`ArgumentError: one of the arguments -n/--name -p/--prefix is required`
Fixed to the correct subcommand order:
`conda env create --file environment.yml`
2. UnicodeDecodeError on Windows when installing via pip
setup.py opens README.md without specifying an encoding, which falls back to the platform's default locale encoding. On Windows this is often cp1252 rather than UTF-8. Since README.md contains UTF-8-only characters (smart quotes, em dashes, →, ≤, α, accented names like "Klein-Flügge"), running pip install git+https://github.com/shawnrhoads/pyEM.git fails on Windows with:
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 11778`
Fixed by explicitly setting encoding="utf-8" when reading the README in setup.py.
Together these two fixes resolve installation failures for Windows users following either the conda or pip installation paths in the README.